### PR TITLE
Make OSX compile

### DIFF
--- a/embedding/components/printingui/mac/nsPrintingPromptServiceX.mm
+++ b/embedding/components/printingui/mac/nsPrintingPromptServiceX.mm
@@ -45,9 +45,8 @@ nsPrintingPromptService::ShowPrintDialog(mozIDOMWindowProxy *parent, nsIWebBrows
   nsCOMPtr<nsIPrintDialogService> dlgPrint(do_GetService(
                                            NS_PRINTDIALOGSERVICE_CONTRACTID));
   if (dlgPrint) {
-    nsCOMPtr<nsPIDOMWindowOuter> outer(do_QueryInterface(parent));
-    return outer ? dlgPrint->Show(outer, printSettings, webBrowserPrint) :
-            NS_ERROR_FAILURE;
+    return dlgPrint->Show(nsPIDOMWindowOuter::From(parent), printSettings,
+                          webBrowserPrint);
   }
 
   return NS_ERROR_FAILURE;
@@ -75,9 +74,7 @@ nsPrintingPromptService::ShowPageSetup(mozIDOMWindowProxy *parent, nsIPrintSetti
   nsCOMPtr<nsIPrintDialogService> dlgPrint(do_GetService(
                                            NS_PRINTDIALOGSERVICE_CONTRACTID));
   if (dlgPrint) {
-    nsCOMPtr<nsPIDOMWindowOuter> outer(do_QueryInterface(parent));
-    return outer ? dlgPrint->ShowPageSetup(outer, printSettings) :
-             NS_ERROR_FAILURE;
+    return dlgPrint->ShowPageSetup(nsPIDOMWindowOuter::From(parent), printSettings);
   }
 
   return NS_ERROR_FAILURE;


### PR DESCRIPTION
I have a try run ongoing at https://treeherder.mozilla.org/#/jobs?repo=try&revision=e0c0571fbe2f. I've tested to make sure that the browser at least starts up and navigates to web pages, but not too much beyond that.

As try results come in, I'll see what I can do to debug them.

There's some real crufty code lying around here! It looks like we might be able to get rid of some of it (nsIPrintStatusFeedback, for example) and a search for m_dialog in mozilla-central shows a bunch of copy/pasted code that only ever reads it unless I'm missing something.
